### PR TITLE
Add Codex AGENTS.md full spec compliance

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -273,7 +273,7 @@ function printSyncSummary(
  * In user scope, files targeting tool-specific dirs go to ~/.<tool>/...
  * In project scope, files are relative to the project root.
  */
-function resolveOutputPath(
+export function resolveOutputPath(
 	relativePath: string,
 	isUserScope: boolean,
 	projectDir: string,
@@ -299,7 +299,12 @@ function resolveOutputPath(
 		}
 	}
 
-	// Root-level files (CLAUDE.md, AGENTS.md, .mcp.json) go to home dir in user scope
+	// AGENTS files go to ~/.codex/ in user scope
+	if (relativePath === "AGENTS.md" || relativePath === "AGENTS.override.md") {
+		return join(USER_OUTPUT_DIRS.codex, relativePath);
+	}
+
+	// Root-level files (CLAUDE.md, .mcp.json) go to home dir in user scope
 	return join(homedir(), relativePath);
 }
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -246,6 +246,7 @@ async function loadDirectives(
 						? frontmatter.description
 						: file.replace(/\.md$/, ""),
 				outputDir: typeof frontmatter.outputDir === "string" ? frontmatter.outputDir : undefined,
+				override: frontmatter.override === true ? true : undefined,
 			};
 			config.directives.push(directive);
 		} catch (e) {

--- a/src/domain/directive.ts
+++ b/src/domain/directive.ts
@@ -19,4 +19,6 @@ export interface Directive {
 	description?: string;
 	/** Optional subdirectory for the emitted file (e.g. "docs-site" → docs-site/CLAUDE.md). */
 	outputDir?: string;
+	/** When true, emit to AGENTS.override.md instead of AGENTS.md (Codex only). */
+	override?: boolean;
 }

--- a/src/emitters/directives.ts
+++ b/src/emitters/directives.ts
@@ -159,9 +159,24 @@ function emitCursor(directives: Directive[]): EmitResult {
 	return { files, warnings };
 }
 
+/** 32 KiB — Codex `project_doc_max_bytes` default. */
+const CODEX_SIZE_LIMIT = 32 * 1024;
+
+/** Warn if file content exceeds the Codex size limit. */
+function checkSizeLimit(path: string, content: string, warnings: string[]): void {
+	const size = new TextEncoder().encode(content).byteLength;
+	if (size > CODEX_SIZE_LIMIT) {
+		warnings.push(
+			`${path} exceeds Codex 32 KiB limit (${(size / 1024).toFixed(1)} KiB) — Codex may truncate it.`,
+		);
+	}
+}
+
 /**
  * Codex:
- * Directives concatenated into <outputDir>/AGENTS.md files, grouped by outputDir.
+ * - enterprise/user scope → skipped with warnings
+ * - project + local → AGENTS.md / AGENTS.override.md (grouped by outputDir)
+ * - override: true → AGENTS.override.md
  */
 function emitCodex(directives: Directive[]): EmitResult {
 	const files: EmittedFile[] = [];
@@ -169,20 +184,58 @@ function emitCodex(directives: Directive[]): EmitResult {
 
 	if (directives.length === 0) return { files, warnings };
 
-	for (const [outputDir, group] of groupByOutputDir(directives)) {
+	// 1. Filter by scope — skip enterprise + user with warnings
+	const enterpriseCount = directives.filter((d) => d.scope === "enterprise").length;
+	if (enterpriseCount > 0) {
+		warnings.push(
+			`Skipping ${enterpriseCount} enterprise-scope directive(s) — no Codex target path for enterprise scope.`,
+		);
+	}
+
+	const userCount = directives.filter((d) => d.scope === "user").length;
+	if (userCount > 0) {
+		warnings.push(
+			`Skipping ${userCount} user-scope directive(s) — use "dotai sync --scope user" to emit these.`,
+		);
+	}
+
+	const remaining = directives.filter((d) => d.scope !== "enterprise" && d.scope !== "user");
+
+	if (remaining.length === 0) return { files, warnings };
+
+	// 2. Split by override flag
+	const overrideDirectives = remaining.filter((d) => d.override);
+	const regularDirectives = remaining.filter((d) => !d.override);
+
+	// 3. Emit regular directives → AGENTS.md per outputDir
+	for (const [outputDir, group] of groupByOutputDir(regularDirectives)) {
 		const sections = group.map((d) => {
 			const header = d.description ? `## ${d.description}` : "## Directive";
 			const scopeNote = d.appliesTo?.length ? `\n\n> Applies to: ${d.appliesTo.join(", ")}` : "";
 			return `${header}${scopeNote}\n\n${d.content}`;
 		});
 
-		files.push({
-			path: prefixPath("AGENTS.md", outputDir),
-			content: `# Project Instructions\n\n${sections.join("\n\n---\n\n")}\n`,
-		});
+		const path = prefixPath("AGENTS.md", outputDir);
+		const content = `# Project Instructions\n\n${sections.join("\n\n---\n\n")}\n`;
+		files.push({ path, content });
+		checkSizeLimit(path, content, warnings);
 	}
 
-	if (directives.some((d) => d.appliesTo?.length)) {
+	// 4. Emit override directives → AGENTS.override.md per outputDir
+	for (const [outputDir, group] of groupByOutputDir(overrideDirectives)) {
+		const sections = group.map((d) => {
+			const header = d.description ? `## ${d.description}` : "## Directive";
+			const scopeNote = d.appliesTo?.length ? `\n\n> Applies to: ${d.appliesTo.join(", ")}` : "";
+			return `${header}${scopeNote}\n\n${d.content}`;
+		});
+
+		const path = prefixPath("AGENTS.override.md", outputDir);
+		const content = `# Project Instructions (Override)\n\n${sections.join("\n\n---\n\n")}\n`;
+		files.push({ path, content });
+		checkSizeLimit(path, content, warnings);
+	}
+
+	if (remaining.some((d) => d.appliesTo?.length)) {
 		warnings.push(
 			"Codex AGENTS.md does not support file-scoped directives — appliesTo patterns are included as notes but not enforced.",
 		);

--- a/tests/emitters/directives.test.ts
+++ b/tests/emitters/directives.test.ts
@@ -171,17 +171,131 @@ describe("directivesEmitter", () => {
 	describe("Codex", () => {
 		it("concatenates all directives into AGENTS.md", () => {
 			const result = directivesEmitter.emit(makeConfig(), "codex");
-			expect(result.files).toHaveLength(1);
-			expect(result.files[0].path).toBe("AGENTS.md");
-			expect(result.files[0].content).toContain("# Project Instructions");
-			expect(result.files[0].content).toContain("Use tabs for indentation.");
-			expect(result.files[0].content).toContain("Write tests with vitest.");
+			const agentsMd = result.files.find((f) => f.path === "AGENTS.md");
+			expect(agentsMd).toBeDefined();
+			expect(agentsMd?.content).toContain("# Project Instructions");
+			expect(agentsMd?.content).toContain("Use tabs for indentation.");
+			expect(agentsMd?.content).toContain("Write tests with vitest.");
 		});
 
 		it("warns about file-scoped directives", () => {
 			const result = directivesEmitter.emit(makeConfig(), "codex");
-			expect(result.warnings.length).toBeGreaterThan(0);
-			expect(result.warnings[0]).toContain("appliesTo");
+			expect(result.warnings).toContainEqual(expect.stringContaining("appliesTo"));
+		});
+
+		it("skips user-scope directives with warning", () => {
+			const config = emptyConfig();
+			config.directives.push(
+				{
+					content: "User pref.",
+					scope: "user",
+					alwaysApply: true,
+					description: "User rule",
+				},
+				{
+					content: "Project rule.",
+					scope: "project",
+					alwaysApply: true,
+					description: "Project rule",
+				},
+			);
+			const result = directivesEmitter.emit(config, "codex");
+			expect(result.files).toHaveLength(1);
+			expect(result.files[0].path).toBe("AGENTS.md");
+			expect(result.files[0].content).not.toContain("User pref.");
+			expect(result.warnings).toContainEqual(
+				expect.stringContaining('user-scope directive(s) — use "dotai sync --scope user"'),
+			);
+		});
+
+		it("skips enterprise-scope directives with warning", () => {
+			const config = emptyConfig();
+			config.directives.push({
+				content: "Enterprise policy.",
+				scope: "enterprise",
+				alwaysApply: true,
+				description: "Enterprise rule",
+			});
+			const result = directivesEmitter.emit(config, "codex");
+			expect(result.files).toHaveLength(0);
+			expect(result.warnings).toContainEqual(
+				expect.stringContaining("enterprise-scope directive(s)"),
+			);
+		});
+
+		it("emits override: true directives to AGENTS.override.md", () => {
+			const config = emptyConfig();
+			config.directives.push(
+				{
+					content: "Normal rule.",
+					scope: "project",
+					alwaysApply: true,
+					description: "Normal",
+				},
+				{
+					content: "Override rule.",
+					scope: "project",
+					alwaysApply: true,
+					description: "Override",
+					override: true,
+				},
+			);
+			const result = directivesEmitter.emit(config, "codex");
+			const agentsMd = result.files.find((f) => f.path === "AGENTS.md");
+			expect(agentsMd).toBeDefined();
+			expect(agentsMd?.content).toContain("Normal rule.");
+			expect(agentsMd?.content).not.toContain("Override rule.");
+
+			const overrideMd = result.files.find((f) => f.path === "AGENTS.override.md");
+			expect(overrideMd).toBeDefined();
+			expect(overrideMd?.content).toContain("Override rule.");
+		});
+
+		it("emits override: true + outputDir to <dir>/AGENTS.override.md", () => {
+			const config = emptyConfig();
+			config.directives.push({
+				content: "Nested override.",
+				scope: "project",
+				alwaysApply: true,
+				description: "Nested",
+				outputDir: "services/api",
+				override: true,
+			});
+			const result = directivesEmitter.emit(config, "codex");
+			const overrideMd = result.files.find((f) => f.path === "services/api/AGENTS.override.md");
+			expect(overrideMd).toBeDefined();
+			expect(overrideMd?.content).toContain("Nested override.");
+		});
+
+		it("warns when content exceeds 32 KiB", () => {
+			const config = emptyConfig();
+			config.directives.push({
+				content: "x".repeat(33 * 1024),
+				scope: "project",
+				alwaysApply: true,
+				description: "Huge",
+			});
+			const result = directivesEmitter.emit(config, "codex");
+			expect(result.warnings).toContainEqual(expect.stringContaining("exceeds Codex 32 KiB limit"));
+		});
+
+		it("override field is ignored for Claude/Cursor/Copilot targets", () => {
+			const config = emptyConfig();
+			config.directives.push({
+				content: "Override ignored.",
+				scope: "project",
+				alwaysApply: true,
+				description: "Special rule",
+				override: true,
+			});
+
+			for (const target of ["claude", "cursor", "copilot"] as const) {
+				const result = directivesEmitter.emit(config, target);
+				// No file should route to AGENTS.override.md
+				expect(result.files.every((f) => !f.path.includes("AGENTS.override"))).toBe(true);
+				// Content should still be emitted
+				expect(result.files.length).toBeGreaterThan(0);
+			}
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Add `override` field to Directive interface, routing `override: true` directives to `AGENTS.override.md` (Codex only, ignored by other targets)
- Rewrite Codex directive emitter with enterprise/user scope filtering (matching Claude emitter pattern), override routing grouped by outputDir, and 32 KiB size limit warning
- Fix user-scope `AGENTS.md` path to route to `~/.codex/` instead of `~/`

## Test plan
- [x] 10 new tests added (6 directive emitter + 4 resolveOutputPath)
- [x] All 266 tests passing
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)