### PR TITLE
Fix Cursor agent emitter to match subagent spec

### DIFF
--- a/src/emitters/agents.ts
+++ b/src/emitters/agents.ts
@@ -93,23 +93,54 @@ function emitClaudeAgents(agents: Agent[]): EmitResult {
 	return { files, warnings };
 }
 
+/** Fields not supported by Cursor agent config. */
+const CURSOR_UNSUPPORTED_AGENT_FIELDS = [
+	"tools",
+	"disallowedTools",
+	"permissionMode",
+	"maxTurns",
+	"skills",
+	"memory",
+	"isolation",
+	"hooks",
+	"mcpServers",
+	"modelReasoningEffort",
+] as const;
+
 /** Cursor: .cursor/agents/<name>.md */
 function emitCursorAgents(agents: Agent[]): EmitResult {
 	const files: EmittedFile[] = [];
+	const warnings: string[] = [];
 	for (const agent of agents) {
 		const frontmatter: string[] = [];
+		frontmatter.push(`name: ${agent.name}`);
 		if (agent.description) frontmatter.push(`description: ${agent.description}`);
 		if (agent.model) frontmatter.push(`model: ${agent.model}`);
 		if (agent.readonly) frontmatter.push(`readonly: true`);
-		if (agent.tools?.length) frontmatter.push(`tools: [${agent.tools.join(", ")}]`);
+		if (agent.background) frontmatter.push(`is_background: true`);
 
-		const header = frontmatter.length > 0 ? `---\n${frontmatter.join("\n")}\n---\n\n` : "";
+		const header = `---\n${frontmatter.join("\n")}\n---\n\n`;
 		files.push({
 			path: `.cursor/agents/${agent.name}.md`,
 			content: `${header}${agent.instructions}\n`,
 		});
+
+		// Warn about unsupported fields
+		for (const field of CURSOR_UNSUPPORTED_AGENT_FIELDS) {
+			const value = agent[field];
+			if (value !== undefined && value !== null) {
+				const hasContent = Array.isArray(value)
+					? value.length > 0
+					: typeof value === "object"
+						? Object.keys(value).length > 0
+						: true;
+				if (hasContent) {
+					warnings.push(`Cursor does not support "${field}" on agent "${agent.name}" — ignored.`);
+				}
+			}
+		}
 	}
-	return { files, warnings: [] };
+	return { files, warnings };
 }
 
 /** Fields not supported by Codex agent config. */

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -218,9 +218,10 @@ Assist with deployment tasks.
 		expect(cursorMcp.mcpServers.github.command).toBe("npx");
 
 		const cursorAgent = await readFile(join(PROJECT, ".cursor/agents/reviewer.md"), "utf-8");
+		expect(cursorAgent).toContain("name: reviewer");
 		expect(cursorAgent).toContain("model: claude-sonnet-4-6");
 		expect(cursorAgent).toContain("readonly: true");
-		expect(cursorAgent).toContain("tools: [Read, Glob, Grep]");
+		expect(cursorAgent).not.toContain("tools:");
 
 		const cursorSkill = await readFile(join(PROJECT, ".cursor/skills/deploy/SKILL.md"), "utf-8");
 		expect(cursorSkill).toContain("# Deploy");

--- a/tests/emitters/agents.test.ts
+++ b/tests/emitters/agents.test.ts
@@ -117,9 +117,41 @@ describe("agentsEmitter", () => {
 			const result = agentsEmitter.emit(makeConfig(), "cursor");
 			expect(result.files).toHaveLength(1);
 			expect(result.files[0].path).toBe(".cursor/agents/reviewer.md");
+			expect(result.files[0].content).toContain("name: reviewer");
+			expect(result.files[0].content).toContain("description: Code review agent");
 			expect(result.files[0].content).toContain("model: claude-sonnet-4-6");
 			expect(result.files[0].content).toContain("readonly: true");
-			expect(result.files[0].content).toContain("tools: [Read, Glob]");
+			expect(result.files[0].content).not.toContain("tools:");
+		});
+
+		it("always emits frontmatter with at least name", () => {
+			const config = emptyConfig();
+			config.agents.push({
+				name: "minimal",
+				description: "",
+				instructions: "Do things.",
+			});
+			const result = agentsEmitter.emit(config, "cursor");
+			expect(result.files[0].content).toContain("---\nname: minimal\n---");
+		});
+
+		it("maps background to is_background", () => {
+			const config = emptyConfig();
+			config.agents.push({
+				name: "bg",
+				description: "Background agent",
+				instructions: "Run in background.",
+				background: true,
+			});
+			const result = agentsEmitter.emit(config, "cursor");
+			expect(result.files[0].content).toContain("is_background: true");
+			expect(result.files[0].content).not.toMatch(/^background:/m);
+		});
+
+		it("warns about unsupported fields", () => {
+			const result = agentsEmitter.emit(makeConfig(), "cursor");
+			expect(result.warnings.some((w) => w.includes('"tools"'))).toBe(true);
+			expect(result.warnings.some((w) => w.includes("Cursor"))).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Emit `name` in frontmatter (always present) and map `background` → `is_background: true` per Cursor's spec
- Remove unsupported `tools` field from Cursor agent output
- Add warnings for all 10 unsupported agent fields (matching Codex emitter pattern)
- Always emit the `---` frontmatter block, even for minimal agents

## Test plan
- [x] All 259 tests pass (`pnpm test`)
- [x] Lint clean (`pnpm lint`)
- [x] Typecheck clean (`pnpm typecheck`)
- [x] New unit tests for `name` emission, `is_background` mapping, minimal frontmatter, and unsupported field warnings
- [x] Updated e2e test to verify no `tools:` in Cursor agent output

🤖 Generated with [Claude Code](https://claude.com/claude-code)