### PR TITLE
fix: sync cursor spec and update globs to array format

### DIFF
--- a/specs/cursor.md
+++ b/specs/cursor.md
@@ -21,20 +21,22 @@
 
 ### Format
 
-Each rule is a separate `.mdc` file in `.cursor/rules/`.
+Each rule is a separate `.mdc` (or `.md`) file in `.cursor/rules/`.
 
 | Property | Value |
 |----------|-------|
 | **Directory** | `.cursor/rules/` (subdirectories supported) |
-| **Naming** | `<slug>.mdc` (Markdown Cursor format) |
+| **Naming** | `<slug>.mdc` (preferred) or `<slug>.md` |
 | **Format** | Markdown with YAML frontmatter |
+
+Supported extensions are `.md` and `.mdc`. dotai emits `.mdc` (preferred format).
 
 ### Frontmatter Schema
 
 ```yaml
 ---
 description: Brief description of when this rule applies
-globs: "**/*.ts, **/*.tsx"
+globs: ["**/*.ts", "**/*.tsx"]
 alwaysApply: true
 ---
 ```
@@ -44,7 +46,7 @@ alwaysApply: true
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
 | `description` | string | No | Describes the rule's purpose |
-| `globs` | string | No | Comma-separated glob patterns for file scoping |
+| `globs` | array | No | Array of glob patterns for file scoping |
 | `alwaysApply` | boolean | No | `true` = always active, `false` = only when matching files |
 
 ### Rule Behavior
@@ -57,6 +59,10 @@ alwaysApply: true
 ### Subdirectory Support
 
 Rules can be placed in `<outputDir>/.cursor/rules/` to scope them to subdirectories.
+
+### AGENTS.md Alternative
+
+Cursor also supports `AGENTS.md` files as a simplified markdown alternative to `.mdc` rules — no frontmatter required. These can be nested in subdirectories for directory-scoped instructions, with more specific files taking precedence over parent-level ones. dotai does not currently emit `AGENTS.md` files (tracked as a known gap).
 
 ---
 
@@ -182,11 +188,19 @@ Same as Claude Code — stdio (default), HTTP, SSE.
 
 ## 6. Ignore Patterns
 
-### Configuration Location
+Cursor supports two ignore files at the project root:
 
-`.cursorignore` (project root)
+### `.cursorignore`
+
+Blocks file access from semantic search, Tab, Agent tools, and `@` mentions entirely.
+
+### `.cursorindexingignore`
+
+Excludes files from codebase indexing only. Files are still accessible by the Agent (useful for large generated/vendored files that shouldn't pollute semantic search but may still be needed at runtime).
 
 ### Format
+
+Both files use `.gitignore` syntax — one pattern per line, comments with `#`:
 
 ```
 # gitignore-style patterns
@@ -196,7 +210,12 @@ dist/**
 .env.*
 ```
 
-Uses `.gitignore` syntax. One pattern per line. Comments with `#`.
+### Additional Options (User Settings)
+
+- **Hierarchical ignore**: Optional setting to traverse parent directories for `.cursorignore` files
+- **Global ignore**: User-level ignore patterns via `Cursor Settings > Features > Editor`
+
+These are user settings, not emitter-generated files.
 
 ---
 
@@ -227,6 +246,8 @@ Cursor does **not** have a file-based hooks system. Hooks configured in dotai wi
 | Agent fields limited | Low | Cursor agents support fewer fields — correct behavior to warn |
 | No hooks support | Medium | Cursor may add hooks in future — monitor docs |
 | No `ask` permission | Low | Only `allow`/`deny` — lossy but acceptable |
+| No `.cursorindexingignore` output | Low | Requires domain model to distinguish indexing-only vs full ignore patterns |
+| No `AGENTS.md` output | Low | Alternative rule format; `.mdc` is preferred and fully supported |
 
 ### Areas to Monitor
 

--- a/specs/cursor.research.json
+++ b/specs/cursor.research.json
@@ -4,14 +4,12 @@
 	"spec": "specs/cursor.md",
 	"llmsTxt": "https://cursor.com/llms.txt",
 	"docs": [
-		"https://cursor.com/docs/rules.md",
-		"https://cursor.com/docs/subagents.md",
-		"https://cursor.com/docs/skills.md",
-		"https://cursor.com/docs/hooks.md",
-		"https://cursor.com/docs/mcp.md",
-		"https://cursor.com/help/customization/ignore-files.md",
-		"https://cursor.com/docs/cli/reference/configuration.md",
-		"https://cursor.com/docs/cli/reference/permissions.md"
+		"https://cursor.com/docs/rules",
+		"https://cursor.com/docs/agent/overview",
+		"https://cursor.com/docs/mcp",
+		"https://cursor.com/docs/reference/ignore-file",
+		"https://cursor.com/docs/cli/reference/configuration",
+		"https://cursor.com/docs/cli/reference/permissions"
 	],
 	"emitters": [
 		"src/emitters/rules.ts",
@@ -30,14 +28,15 @@
 		"ignore": ".cursorignore"
 	},
 	"notes": [
-		"Rules use .mdc extension (Markdown Cursor), not .md",
-		"Rules frontmatter uses 'globs' (comma-separated string), not 'paths' (YAML array)",
+		"Rules use .mdc extension (preferred) — .md is also supported per docs",
+		"Rules frontmatter uses 'globs' as a YAML array (e.g. [\"**/*.ts\"]), not a comma-separated string",
+		"Cursor also supports AGENTS.md files as a no-frontmatter alternative to .mdc rules — not emitted by dotai",
 		"Agent support is limited — no tools, hooks, mcpServers, permissionMode fields",
 		"Cursor uses 'is_background' for background agents (not 'background')",
 		"MCP format matches Claude Code (.mcp.json style with mcpServers key)",
 		"Permissions only support allow/deny — no 'ask' decision",
 		"No hooks support at all — hooks produce warnings and are skipped",
-		"Cursor updates frequently — doc URLs may change",
-		"Skills may use same format as Claude Code but verify support level"
+		".cursorindexingignore is a second ignore file for indexing-only exclusion (not yet emitted by dotai)",
+		"Cursor updates frequently — doc URLs may change"
 	]
 }

--- a/src/emitters/rules/cursor.ts
+++ b/src/emitters/rules/cursor.ts
@@ -18,7 +18,8 @@ export function emitCursor(rules: Rule[]): EmitResult {
 			frontmatter.push(`description: ${rule.description}`);
 		}
 		if (rule.appliesTo?.length) {
-			frontmatter.push(`globs: ${rule.appliesTo.join(", ")}`);
+			const globList = rule.appliesTo.map((g) => `"${g}"`).join(", ");
+			frontmatter.push(`globs: [${globList}]`);
 		}
 		frontmatter.push(`alwaysApply: ${rule.alwaysApply}`);
 

--- a/tests/emitters/rules/cursor.test.ts
+++ b/tests/emitters/rules/cursor.test.ts
@@ -31,7 +31,7 @@ describe("rulesEmitter — cursor", () => {
 
 		const testing = result.files.find((f) => f.path.includes("testing"));
 		expect(testing).toBeDefined();
-		expect(testing?.content).toContain("globs: **/*.test.ts");
+		expect(testing?.content).toContain('globs: ["**/*.test.ts"]');
 		expect(testing?.content).toContain("alwaysApply: false");
 	});
 


### PR DESCRIPTION
Addresses spec drift detected in #issues/4.

## Changes

- `globs` frontmatter in Cursor rules emitter changed from comma-separated string to YAML array format per current Cursor docs
- Updated `specs/cursor.md`: array globs, .md extension support, AGENTS.md alternative, .cursorindexingignore documentation, new known gaps
- Updated `specs/cursor.research.json` with current doc URLs and accurate notes
- Updated test assertions for new globs array format

Closes #4

Generated with [Claude Code](https://claude.ai/code)