### PR TITLE
Update links in overview.md to correct page

### DIFF
--- a/docs-site/src/content/docs/concepts/overview.md
+++ b/docs-site/src/content/docs/concepts/overview.md
@@ -41,11 +41,11 @@ When the same key appears at multiple scopes, the narrower scope wins for settin
 
 ## Further Reading
 
-- [Rules](./rules) — persistent textual instructions
-- [Skills](./skills) — reusable knowledge packages
-- [Agents](./agents) — specialized sub-agents
-- [Tool Servers](./tool-servers) — MCP providers
-- [Hooks](./hooks) — lifecycle event handlers
-- [Permissions](./permissions) — access control
-- [Settings](./settings) — key-value configuration
-- [Ignore Patterns](./ignore-patterns) — file exclusion rules
+- [Rules](../rules) — persistent textual instructions
+- [Skills](../skills) — reusable knowledge packages
+- [Agents](../ai-agents) — specialized sub-agents
+- [Tool Servers](../tool-servers) — MCP providers
+- [Hooks](../hooks) — lifecycle event handlers
+- [Permissions](../permissions) — access control
+- [Settings](../settings) — key-value configuration
+- [Ignore Patterns](../ignore-patterns) — file exclusion rules


### PR DESCRIPTION
## What
routes get a 404 since they go to /concepts/overview/{page}
## Why

## Affected targets
<!-- Which AI tools are affected? claude / cursor / codex / copilot / none -->

## Checklist
- [ ] `pnpm test` passes
- [ ] Changeset added (if user-facing): `pnpm changeset`
- [ ] No upward imports (layer boundaries respected)
- [ ] Emitter changes checked against `specs/`
- [ ] Snapshots updated if emitter output changed (`pnpm test -- --update`)
- [ ] New domain types have factory + type guard + re-export
- [ ] Docs updated if user-facing behavior changed (`docs-site/` and/or `CLAUDE.md`)
